### PR TITLE
Fix for longer JSON responses

### DIFF
--- a/lib/api_service.js
+++ b/lib/api_service.js
@@ -28,13 +28,14 @@ module.exports = {
                 }
                 res.setEncoding('utf8');
 
-                var response_data;
-                res.on('data', function (body) {
-                    // console.log('BODY: ' + body);
-                    response_data = JSON.parse(body)[0];
+                var body = '';
+                res.on('data', function (chunk) {
+                    // console.log('BODY: ' + chunk);
+                    body += chunk;
                 });
                 res.on('end', function () {
                     try {
+                        let response_data = JSON.parse(body)[0];
                         resolve(response_data);
                     } catch (error) {
                         reject(error);


### PR DESCRIPTION
This is the normal way to accumulate and parse the content of an HTTP response whose content spans multiple `.on('data', ...)` events.